### PR TITLE
Add default_context_options to linux_usbfs.c

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -109,6 +109,7 @@ usbi_mutex_static_t linux_hotplug_lock = USBI_MUTEX_INITIALIZER;
 static int linux_scan_devices(struct libusb_context *ctx);
 static int detach_kernel_driver_and_claim(struct libusb_device_handle *, uint8_t);
 static int parse_config_descriptors(struct libusb_device *dev);
+static struct usbi_option default_context_options[LIBUSB_OPTION_MAX];
 
 #if !defined(HAVE_LIBUDEV)
 static int linux_default_scan_devices(struct libusb_context *ctx);


### PR DESCRIPTION
I get an error when compiling this library for Android: 
`libusb\libusb\os\linux_usbfs.c:425:3: error: use of undeclared identifier 'default_context_options'`

Not sure if it is the best solution, but adding it at the beginning fixes the error.